### PR TITLE
Improve the setup tutorial

### DIFF
--- a/ryr-docs/docs/contributor-zone/technical-overview.md
+++ b/ryr-docs/docs/contributor-zone/technical-overview.md
@@ -16,13 +16,13 @@ The tasks will be handled by [Celery](http://docs.celeryproject.org/en/latest/in
 
 ALL the documentation is written in [reStructuredText](ttp://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html) and generated with [Sphinx](http://www.sphinx-doc.org/en/stable/)
 
-Repository: [API](https://github.com/rgreinho/request-yo-racks-api)
+Repository: [API](https://github.com/request-yo-racks/api)
 
 ## Web
 
 The frontend is a [Progressive Web Application (PWA)](https://developers.google.com/web/progressive-web-apps/). The [Polymer](https://www.polymer-project.org/) library offers the ability to quickly create a PWA implementing the [PRPL pattern](https://developers.google.com/web/fundamentals/performance/prpl-pattern/), and to build[ web components](https://www.webcomponents.org/).
 
-Repository: [Web](https://github.com/rgreinho/request-yo-racks-web)
+Repository: [Web](https://github.com/request-yo-racks/web)
 
 ## Infrastructure
 

--- a/ryr-docs/docs/guides/setup-full-environment.md
+++ b/ryr-docs/docs/guides/setup-full-environment.md
@@ -1,6 +1,13 @@
 # How to setup a full environment?
 
-First, you will need a [Yelp](https://www.yelp.com/signup) and [Google](https://accounts.google.com/SignUp) account, as well as developer keys for some of their services.
+## Accounts
+
+First, you will need:
+
+* A [Yelp](https://www.yelp.com/signup) account
+* A [Google](https://accounts.google.com/SignUp) account
+
+## Developer keys
 
 Create a developer Key for:
 
@@ -8,6 +15,7 @@ Create a developer Key for:
 * [Google Places API](https://developers.google.com/places/web-service)
 * [Google Geocoding API](https://developers.google.com/maps/documentation/geocoding/get-api-key)
 
+## Environment variables
 
 Once your accounts are setup, store your developer keys in a global environment file:
 ``` bash
@@ -22,7 +30,9 @@ EOF
 chmod 400 "${RYR_GLOBAL_CONFIG_DIR}/ryr-env.sh"
 ```
 
-Then create a folder which will contain the RYR projects:
+## Clone the projects
+
+Create a folder which will contain the RYR projects:
 ``` bash
 RYR_PROJECT_DIR="${HOME}/projects/request-yo-racks"
 mkdir -p "${RYR_PROJECT_DIR}"
@@ -33,6 +43,8 @@ done
 ```
 
 Each project can be simply setup with the `make` command, and a local developer environment is provided via `docker-compose`.
+
+## Start the services
 
 You can start the API service and the frontend like this:
 ``` bash

--- a/ryr-docs/mkdocs.yml
+++ b/ryr-docs/mkdocs.yml
@@ -4,8 +4,8 @@ pages:
   - Contributor Zone:
     - Goals & Strategy: contributor-zone/goals-strategy.md
     - Technical Overview: 'contributor-zone/technical-overview.md'
-  - How-to:
-    - Setup full environment: 'how-to/setup-full-environment.md'
+  - Guides:
+    - Setup full environment: 'guides/setup-full-environment.md'
   - About:
     - 'License': 'about/license.md'
 theme:


### PR DESCRIPTION
Make the setup tutorial more clear by splitting each step into its own
section.

Drive-bys:
* Fix broken links
* Rename "how-tos" to "Guides"