### PR TITLE
Fix CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - deps-{{ checksum "requirements/local.txt" }}
+          - deps-{{ checksum "requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
           - deps-
 
@@ -23,7 +23,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: deps-{{ checksum "requirements/local.txt" }}
+          key: deps-{{ checksum "requirements.txt" }}
 
       - run:
           name: Build the site.
@@ -41,7 +41,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - deps-{{ checksum "requirements/local.txt" }}
+          - deps-{{ checksum "requirements.txt" }}
           - deps-
 
       - add_ssh_keys:


### PR DESCRIPTION
The wrong `requirements.txt` file was used for caching the dependencies
in CircleCI.